### PR TITLE
exception because of Error Prone static analysis plugin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ META-INF
 out
 build
 .gradle
-
+.sdkmanrc

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ repositories {
  * Add errorprone checking.
  */
 dependencies {
-    errorprone("com.google.errorprone:error_prone_core:2.3.3")
+    errorprone("com.google.errorprone:error_prone_core:2.3.4")
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
 }
 


### PR DESCRIPTION
    * Bumped error prone version to 2.3.4 to fix a known issue with the library
    * Added new entry to .gitignore

Fixes #10 