### PR TITLE
Fixed most CVE vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ META-INF
 out
 build
 .gradle
-
+.sdkmanrc

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,15 @@ buildscript {
         mavenCentral()
         maven {
             url "https://repo.spring.io/plugins-snapshot";
+            content {
+                includeGroupByRegex "io\\.spring\\.gradle\\.*"
+            }
         }
     }
     dependencies {
         classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:4.2.0'
         classpath 'io.spring.gradle:propdeps-plugin:0.0.8-SNAPSHOT'
+        classpath 'org.owasp:dependency-check-gradle:8.2.1'
     }
 };
 
@@ -51,7 +55,7 @@ apply(plugin: "biz.aQute.bnd.builder");
 apply(plugin: "idea");
 apply(plugin: "eclipse");
 apply(plugin: "net.ltgt.errorprone");
-
+apply(plugin: 'org.owasp.dependencycheck');
 apply(from: "project.gradle");
 
 group = "com.github.java-json-tools";
@@ -70,7 +74,7 @@ repositories {
  * Add errorprone checking.
  */
 dependencies {
-    errorprone('com.google.errorprone:error_prone_core:2.18.0')
+    errorprone('com.google.errorprone:error_prone_core:2.20.0')
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
 }
 

--- a/project.gradle
+++ b/project.gradle
@@ -30,8 +30,8 @@ project.ext.description = "JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7386)
  */
 dependencies {
     provided(group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2");
-    compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.11.0");
-    compile(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.6.0')
+    compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.15.2");
+    compile(group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0')
     compile(group: "com.github.java-json-tools", name: "msg-simple", version: "1.2");
     compile(group: "com.github.java-json-tools", name: "jackson-coreutils", version: "2.0");
     testCompile(group: "org.testng", name: "testng", version: "7.1.0") {

--- a/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/JsonPatchOperation.java
@@ -33,12 +33,12 @@ import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
-
 import java.util.EnumSet;
 import java.util.Set;
 
-import static com.fasterxml.jackson.annotation.JsonSubTypes.*;
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
+import static com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "op")
 
@@ -51,7 +51,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
         @Type(name = "test", value = TestOperation.class)
 })
 
-/**
+/*
  * Base abstract class for one patch operation
  *
  * <p>Two more abstract classes extend this one according to the arguments of
@@ -63,6 +63,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.*;
  *     <li>{@link PathValueOperation} for operations taking a value as an
  *     argument ({@code add}, {@code replace} and {@code test}).</li>
  * </ul>
+ *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class JsonPatchOperation implements JsonSerializable {


### PR DESCRIPTION
Fixed most CVE vulnerabilities found in dependencies.

Added CVE checker for gradle.

The only vulnerabilities left are within guava (which is used in errorprone):

guava-31.1-jre.jar (pkg:maven/com.google.guava/guava@31.1-jre, cpe:2.3:a:google:guava:31.1:*:*:*:*:*:*:*) : CVE-2023-2976, CVE-2020-8908

The above issue will not be fixed.