### PR TITLE
Allow users to customise the ObjectMapper used in JsonMergePatch deserialization

### DIFF
--- a/src/main/java/com/gravity9/jsonpatch/mergepatch/JsonMergePatch.java
+++ b/src/main/java/com/gravity9/jsonpatch/mergepatch/JsonMergePatch.java
@@ -65,9 +65,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @JsonDeserialize(using = JsonMergePatchDeserializer.class)
 public abstract class JsonMergePatch implements JsonSerializable, Patch {
 
-	protected static final MessageBundle BUNDLE
-		= MessageBundles.getBundle(JsonPatchMessages.class);
-	private static final ObjectMapper MAPPER = JacksonUtils.newMapper();
+	protected static final MessageBundle BUNDLE = MessageBundles.getBundle(JsonPatchMessages.class);
+	private static final ObjectMapper DEFAULT_MAPPER = JacksonUtils.newMapper();
 
 	/**
 	 * Build an instance from a JSON input
@@ -77,11 +76,25 @@ public abstract class JsonMergePatch implements JsonSerializable, Patch {
 	 * @throws JsonPatchException   failed to deserialize
 	 * @throws NullPointerException node is null
 	 */
-	public static JsonMergePatch fromJson(final JsonNode node)
-		throws JsonPatchException {
+	public static JsonMergePatch fromJson(final JsonNode node) throws JsonPatchException {
+		return fromJson(node, DEFAULT_MAPPER);
+	}
+
+	/**
+	 * Build an instance from a JSON input with a custom ObjectMapper.
+	 * This allows to customize the mapper used in deserialization of nodes.
+	 *
+	 * @param node   the input
+	 * @param mapper custom ObjectMapper
+	 * @return a JSON Merge Patch instance
+	 * @throws JsonPatchException   failed to deserialize
+	 * @throws NullPointerException node or mapper is null
+	 */
+	public static JsonMergePatch fromJson(final JsonNode node, ObjectMapper mapper) throws JsonPatchException {
 		BUNDLE.checkNotNull(node, "jsonPatch.nullInput");
+		BUNDLE.checkNotNull(mapper, "jsonPatch.nullInput");
 		try {
-			return MAPPER.readValue(node.traverse(), JsonMergePatch.class);
+			return mapper.readValue(node.traverse(), JsonMergePatch.class);
 		} catch (IOException e) {
 			throw new JsonPatchException(
 				BUNDLE.getMessage("jsonPatch.deserFailed"), e);

--- a/src/main/java/com/gravity9/jsonpatch/mergepatch/NonObjectMergePatch.java
+++ b/src/main/java/com/gravity9/jsonpatch/mergepatch/NonObjectMergePatch.java
@@ -20,11 +20,9 @@
 package com.gravity9.jsonpatch.mergepatch;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import com.gravity9.jsonpatch.JsonPatchException;
 import java.io.IOException;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -41,23 +39,21 @@ final class NonObjectMergePatch extends JsonMergePatch {
 	}
 
 	@Override
-	public JsonNode apply(final JsonNode input)
-		throws JsonPatchException {
+	public JsonNode apply(final JsonNode input) {
 		BUNDLE.checkNotNull(input, "jsonPatch.nullValue");
 		return node;
 	}
 
 	@Override
 	public void serialize(final JsonGenerator jgen,
-						  final SerializerProvider provider)
-		throws IOException, JsonProcessingException {
+						  final SerializerProvider provider) throws IOException {
 		jgen.writeTree(node);
 	}
 
 	@Override
 	public void serializeWithType(final JsonGenerator jgen,
-								  final SerializerProvider provider, final TypeSerializer typeSer)
-		throws IOException, JsonProcessingException {
+								  final SerializerProvider provider,
+								  final TypeSerializer typeSer) throws IOException {
 		serialize(jgen, provider);
 	}
 }

--- a/src/main/java/com/gravity9/jsonpatch/mergepatch/ObjectMergePatch.java
+++ b/src/main/java/com/gravity9/jsonpatch/mergepatch/ObjectMergePatch.java
@@ -20,7 +20,6 @@
 package com.gravity9.jsonpatch.mergepatch;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
@@ -44,13 +43,12 @@ final class ObjectMergePatch extends JsonMergePatch {
 
 	ObjectMergePatch(final Set<String> removedMembers,
 					 final Map<String, JsonMergePatch> modifiedMembers) {
-		this.removedMembers = Collections.unmodifiableSet(new HashSet<String>(removedMembers));
-		this.modifiedMembers = Collections.unmodifiableMap(new HashMap<String, JsonMergePatch>(modifiedMembers));
+		this.removedMembers = Collections.unmodifiableSet(new HashSet<>(removedMembers));
+		this.modifiedMembers = Collections.unmodifiableMap(new HashMap<>(modifiedMembers));
 	}
 
 	@Override
-	public JsonNode apply(final JsonNode input)
-		throws JsonPatchException {
+	public JsonNode apply(final JsonNode input) throws JsonPatchException {
 		BUNDLE.checkNotNull(input, "jsonPatch.nullValue");
 		/*
 		 * If the input is an object, we make a deep copy of it
@@ -90,8 +88,7 @@ final class ObjectMergePatch extends JsonMergePatch {
 
 	@Override
 	public void serialize(final JsonGenerator jgen,
-						  final SerializerProvider provider)
-		throws IOException, JsonProcessingException {
+						  final SerializerProvider provider) throws IOException {
 		jgen.writeStartObject();
 
 		/*
@@ -114,8 +111,8 @@ final class ObjectMergePatch extends JsonMergePatch {
 
 	@Override
 	public void serializeWithType(final JsonGenerator jgen,
-								  final SerializerProvider provider, final TypeSerializer typeSer)
-		throws IOException, JsonProcessingException {
+								  final SerializerProvider provider,
+								  final TypeSerializer typeSer) throws IOException {
 		serialize(jgen, provider);
 	}
 }

--- a/src/test/java/com/gravity9/jsonpatch/mergepatch/SerializationTest.java
+++ b/src/test/java/com/gravity9/jsonpatch/mergepatch/SerializationTest.java
@@ -19,8 +19,10 @@
 
 package com.gravity9.jsonpatch.mergepatch;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.github.fge.jackson.JacksonUtils;
 import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jackson.JsonNumEquals;
@@ -34,6 +36,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
 
 public final class SerializationTest {
 
@@ -101,5 +104,18 @@ public final class SerializationTest {
 		final JsonNode serialized = JacksonUtils.getReader().readTree(out);
 
 		assertTrue(EQUIVALENCE.equivalent(input, serialized));
+	}
+
+	@Test
+	void testDecimalsKeptAfterPatchWithCustomObjectMapper() throws Exception {
+		ObjectMapper mapper = new ObjectMapper()
+			.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+			.setNodeFactory(new JsonNodeFactory(true));
+
+		JsonNode newer = mapper.readTree("25.000");
+		JsonNode older = mapper.readTree("24.444");
+		JsonNode apply = JsonMergePatch.fromJson(newer, mapper).apply(older);
+
+		assertEquals("25.000", apply.asText());
 	}
 }


### PR DESCRIPTION
Allow users to customise the ObjectMapper used in JsonMergePatch deserialization

    * Added a method to JsonMergePatch that takes custom ObjectMapper
    * Code cleanup

Resolves #42 