### PR TITLE
New test examples to test.json

### DIFF
--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -62,6 +62,28 @@
                 ]
             },
             "message": "value differs from expectations: expected '{\"value\":\"Open\",\"onclick\":\"CreateNewDoc()\"}' but found '{\"value\":\"Close\",\"onclick\":\"CloseDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/3", "value": {"value": "Open", "onclick": "CreateNewDoc()"}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":\"Open\",\"onclick\":\"CreateNewDoc()\"}' but found 'null'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/0", "value": {"value": {}, "onclick": "CreateNewDoc()"}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":{},\"onclick\":\"CreateNewDoc()\"}' but found '{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"}'"
         }
     ],
     "ops": [

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -40,6 +40,17 @@
                 ]
             },
             "message": "value differs from expectations: expected '{\"value\":\"Close\",\"onclick\":\"OpenDoc()\"}' but found '{\"value\":\"Open\",\"onclick\":\"OpenDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/0", "value": {"value": "New", "onclick": "OpenDoc()"}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":\"New\",\"onclick\":\"OpenDoc()\"}' but found '{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"}'"
         }
     ],
     "ops": [

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -42,7 +42,7 @@
             "message": "value differs from expectations: expected '{\"value\":\"Close\",\"onclick\":\"OpenDoc()\"}' but found '{\"value\":\"Open\",\"onclick\":\"OpenDoc()\"}'"
         },
         {
-            "op": { "op": "test", "path": "/menu/0", "value": {"value": "New", "onclick": "OpenDoc()"}},
+            "op": { "op": "test", "path": "/menu/0", "value": {"value": "New", "onclick": "CloseDoc()"}},
             "node": {
                 "menu": [
                     {"value": "New", "onclick": "CreateNewDoc()"},
@@ -50,7 +50,18 @@
                     {"value": "Close", "onclick": "CloseDoc()"}
                 ]
             },
-            "message": "value differs from expectations: expected '{\"value\":\"New\",\"onclick\":\"OpenDoc()\"}' but found '{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"}'"
+            "message": "value differs from expectations: expected '{\"value\":\"New\",\"onclick\":\"CloseDoc()\"}' but found '{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/2", "value": {"value": "Open", "onclick": "CreateNewDoc()"}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":\"Open\",\"onclick\":\"CreateNewDoc()\"}' but found '{\"value\":\"Close\",\"onclick\":\"CloseDoc()\"}'"
         }
     ],
     "ops": [

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -29,6 +29,17 @@
             "op": { "op": "test", "path": "/isActive", "value": false },
             "node": {"isActive": true },
             "message": "value differs from expectations: expected 'false' but found 'true'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/1", "value": {"value": "Close", "onclick": "OpenDoc()"}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":\"Close\",\"onclick\":\"OpenDoc()\"}' but found '{\"value\":\"Open\",\"onclick\":\"OpenDoc()\"}'"
         }
     ],
     "ops": [

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -106,6 +106,17 @@
                 ]
             },
             "message": "value differs from expectations: expected '{\"value\":{},\"onclick\":{}}' but found '{\"value\":\"Close\",\"onclick\":\"CloseDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/3", "value": {"value": {}, "onclick": {}}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":{},\"onclick\":{}}' but found 'null'"
         }
     ],
     "ops": [

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -84,6 +84,28 @@
                 ]
             },
             "message": "value differs from expectations: expected '{\"value\":{},\"onclick\":\"CreateNewDoc()\"}' but found '{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/1", "value": {"value": "Open", "onclick": {}}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":\"Open\",\"onclick\":{}}' but found '{\"value\":\"Open\",\"onclick\":\"OpenDoc()\"}'"
+        },
+        {
+            "op": { "op": "test", "path": "/menu/2", "value": {"value": {}, "onclick": {}}},
+            "node": {
+                "menu": [
+                    {"value": "New", "onclick": "CreateNewDoc()"},
+                    {"value": "Open", "onclick": "OpenDoc()"},
+                    {"value": "Close", "onclick": "CloseDoc()"}
+                ]
+            },
+            "message": "value differs from expectations: expected '{\"value\":{},\"onclick\":{}}' but found '{\"value\":\"Close\",\"onclick\":\"CloseDoc()\"}'"
         }
     ],
     "ops": [


### PR DESCRIPTION
I've added a few more examples to test.json with 'menu' inside 'node'.